### PR TITLE
Allow PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tebru/dynamo",
     "description": "Generates PHP classes from an interface based on doctrine annotations",
     "require": {
-        "php": ">= 5.4, <7",
+        "php": ">= 5.4",
         "nikic/php-parser": "~1.3",
         "doctrine/annotations": "~1.0",
         "tebru/assert": "^0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a67911d90aa3e7497f164fe56e16db67",
-    "content-hash": "1887c556ba5414374ad8919d0d90fcc0",
+    "hash": "a515fe85fef9fb5ce2535ce09ee5131f",
+    "content-hash": "a9dba8a8f861bb54c9f06ffa0a0ed288",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1720,61 +1720,6 @@
             "time": "2016-02-28 16:24:34"
         },
         {
-            "name": "symfony/phpunit-bridge",
-            "version": "v3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "4580ae86cde5497d38fc971192cd2c37e546eb4f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/4580ae86cde5497d38fc971192cd2c37e546eb4f",
-                "reference": "4580ae86cde5497d38fc971192cd2c37e546eb4f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "suggest": {
-                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
-            },
-            "type": "symfony-bridge",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Bridge\\PhpUnit\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony PHPUnit Bridge",
-            "homepage": "https://symfony.com",
-            "time": "2016-01-21 09:38:31"
-        },
-        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.1.1",
             "source": {
@@ -1938,7 +1883,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 5.4, <7"
+        "php": ">= 5.4"
     },
     "platform-dev": {
         "php": ">= 5.5"


### PR DESCRIPTION
So far, all the tests pass with PHP 7.0.3. Why not allow it?
